### PR TITLE
fix(hero): buffered jump no longer triggers flip

### DIFF
--- a/src/entities/Hero.ts
+++ b/src/entities/Hero.ts
@@ -8,7 +8,7 @@ class Hero extends Phaser.GameObjects.Sprite {
   private moveState!: any;
   private movePredicates!: Record<string, () => boolean>;
   private controlState: {
-    didPressJump?: boolean;
+    didJustPressJump?: boolean;
     jumpBufferedUntil?: number;
     lastOnFloorTime?: number;
   } = {};
@@ -16,7 +16,9 @@ class Hero extends Phaser.GameObjects.Sprite {
   private jumpKey?: Phaser.Input.Keyboard.Key;
   private sprintKey?: Phaser.Input.Keyboard.Key;
 
+  // Let a slightly-early jump press trigger on landing.
   private readonly jumpBufferMs = 200;
+  // Let the player still jump for a brief moment after walking off a ledge.
   private readonly coyoteTimeMs = 120;
   private readonly flipGraceMs = 650;
   private readonly spawnInvulnerabilityMs = 700;
@@ -204,7 +206,7 @@ class Hero extends Phaser.GameObjects.Sprite {
         const withinGrace = now - lastOnFloor <= this.flipGraceMs;
 
         return (
-          this.controlState.didPressJump &&
+          this.controlState.didJustPressJump &&
           !this.body.onFloor() &&
           (this.body.velocity.y < 0 || withinGrace)
         );
@@ -277,14 +279,12 @@ class Hero extends Phaser.GameObjects.Sprite {
       Phaser.Input.Keyboard.JustDown(this.keys.up) ||
       (this.jumpKey ? Phaser.Input.Keyboard.JustDown(this.jumpKey) : false);
 
+    this.controlState.didJustPressJump = !this.isDead() && didJustPressJump;
+
     if (!this.isDead() && didJustPressJump) {
       this.controlState.jumpBufferedUntil =
         this.scene.time.now + this.jumpBufferMs;
     }
-
-    this.controlState.didPressJump =
-      !this.isDead() &&
-      (this.controlState.jumpBufferedUntil ?? 0) > this.scene.time.now;
 
     const isSprinting = this.isSprintJumpActive();
     const isFastFalling =


### PR DESCRIPTION
This PR fixes an input edge case in the hero movement state machine.

When you press jump slightly before landing, that input is buffered so the character jumps on touchdown. Previously, that same buffered state could also satisfy the mid-air flip predicate, causing an unexpected flip instead of a buffered landing jump.

Changes:
- Track a true "just pressed jump this frame" flag for flip gating
- Keep jump buffering behavior intact for landing/coyote-time jumps

Notes:
- I was unable to run `yarn install`/`yarn build` in this environment due to a DNS resolution error reaching `registry.yarnpkg.com`.
